### PR TITLE
Update DOI resolver to preferred URL

### DIFF
--- a/mappings/commons/Mapping_commons:Doi.ttl
+++ b/mappings/commons/Mapping_commons:Doi.ttl
@@ -105,7 +105,7 @@
 ### Parameters
 <SimplePropertyMapping/7/FTM/FV/prefixParameterPOM>
         a             rr:PredicateObjectMap ;
-        rr:object     "http://dx.doi.org/" ;
+        rr:object     "https://doi.org/" ;
         rr:predicate  dbf:prefixParameter .
 
 <SimplePropertyMapping/7/FTM/FV/propertyParameterPOM>


### PR DESCRIPTION
I'm not really sure about this change. Is the object value used for matching (in this case, better don't merge) or for constructing URLs (in that case, see https://www.doi.org/doi_handbook/3_Resolution.html#3.8)?